### PR TITLE
Remove unused/unnecessary fields.

### DIFF
--- a/whisk/api.go
+++ b/whisk/api.go
@@ -148,10 +148,6 @@ type ApiSwagger struct {
 	BasePath    string                     `json:"basePath,omitempty"`
 	Info        *ApiSwaggerInfo            `json:"info,omitempty"`
 	Paths       map[string]*ApiSwaggerPath `json:"paths,omitempty"`
-	SecurityDef interface{}                `json:"securityDefinitions,omitempty"`
-	Security    interface{}                `json:"security,omitempty"`
-	XConfig     interface{}                `json:"x-ibm-configuration,omitempty"`
-	XRateLimit  interface{}                `json:"x-ibm-rate-limit,omitempty"`
 }
 
 type ApiSwaggerPath struct {


### PR DESCRIPTION
I did not find references to these fields. 
Are these fields present to copy propagate or some other reason?

