### PR TITLE
Add omit tag to ErrorResponse.Response field

### DIFF
--- a/whisk/client.go
+++ b/whisk/client.go
@@ -645,7 +645,7 @@ func parseSuccessResponse(resp *http.Response, data []byte, v interface{}) *http
 //     "code": "1422870"
 // }
 type ErrorResponse struct {
-	Response *http.Response // HTTP response that caused this error
+	Response *http.Response `json:"-"`     // HTTP response that caused this error
 	ErrMsg   *interface{}   `json:"error"` // error message string
 	Code     *interface{}   `json:"code"`  // validation error code (tid)
 }


### PR DESCRIPTION
In the following code, `resp` is overwritten by `activation.response` field when called `d.Decode(&errorResponse)`. So `resp.StatusCode` is changed to activation's status code, not HTTP response status code. This causes `parseApplicationError` never calls when parsing action developer error activation.

https://github.com/apache/incubator-openwhisk-client-go/blob/4286a8212a74c40d8950ee76681a67e12c9bf1a0/whisk/client.go#L557-L569

This PR changes to ignore `ErrorResponse.Response` field on parsing.

- [x] I have signed a CLA