### PR TITLE
Add updated field on Action struct

### DIFF
--- a/whisk/action.go
+++ b/whisk/action.go
@@ -41,6 +41,7 @@ type Action struct {
 	Error       string      `json:"error,omitempty"`
 	Code        int         `json:"code,omitempty"`
 	Publish     *bool       `json:"publish,omitempty"`
+	Updated     int64       `json:"updated"`
 }
 
 type Exec struct {

--- a/whisk/action.go
+++ b/whisk/action.go
@@ -41,7 +41,7 @@ type Action struct {
 	Error       string      `json:"error,omitempty"`
 	Code        int         `json:"code,omitempty"`
 	Publish     *bool       `json:"publish,omitempty"`
-	Updated     int64       `json:"updated"`
+	Updated     int64       `json:"updated,omitempty"`
 }
 
 type Exec struct {


### PR DESCRIPTION
## Description

It is related to this PR https://github.com/apache/openwhisk/pull/4646

Since there is no `updated` field in the Action structure, `wsk action get ` command doesn't show a `updated` value even though the API passed it.

I think this PR can be merged after the openwhisk-core PR is merged

## TEST

```
Response body received:
{"annotations":[],"exec":{"kind":"nodejs:10","binary":false},"limits":{"concurrency":1,"logs":10,"memory":128,"timeout":60000},"name":"invokerHealthTestAction0","namespace":"whisk.system","parameters":[],"publish":false,"updated":1569485478259,"version":"0.0.1"}
ok: got action invokerHealthTestAction0
{
    "namespace": "whisk.system",
    "name": "invokerHealthTestAction0",
    "version": "0.0.1",
    "exec": {
        "kind": "nodejs:10",
        "binary": false
    },
    "limits": {
        "timeout": 60000,
        "memory": 128,
        "logs": 10,
        "concurrency": 1
    },
    "publish": false,
    "updated": 1569485478259
}
```