### PR TITLE
Add `updated` field on package, rule, and trigger entity

### DIFF
--- a/whisk/package.go
+++ b/whisk/package.go
@@ -46,6 +46,7 @@ type Package struct {
 	Binding     *Binding    `json:"binding,omitempty"`
 	Actions     []Action    `json:"actions,omitempty"`
 	Feeds       []Action    `json:"feeds,omitempty"`
+	Updated     int64       `json:"updated,omitempty"`
 }
 
 func (p *Package) GetName() string {

--- a/whisk/rule.go
+++ b/whisk/rule.go
@@ -39,6 +39,7 @@ type Rule struct {
 	Trigger     interface{} `json:"trigger"`
 	Action      interface{} `json:"action"`
 	Publish     *bool       `json:"publish,omitempty"`
+	Updated     int64       `json:"updated,omitempty"`
 }
 
 type RuleListOptions struct {

--- a/whisk/trigger.go
+++ b/whisk/trigger.go
@@ -40,6 +40,7 @@ type Trigger struct {
 	Limits       *Limits                `json:"limits,omitempty"`
 	Publish      *bool                  `json:"publish,omitempty"`
 	Rules        map[string]interface{} `json:"rules,omitempty"`
+	Updated      int64                  `json:"updated,omitempty"`
 }
 
 type TriggerListOptions struct {


### PR DESCRIPTION
## Description

In the previous PR #129, the updated field was added only to the Action structure. So, I've added this field to the Package, Rule, and Trigger structure as well.

This PR is related to the following two PRs:
- https://github.com/apache/openwhisk/pull/4646 (Serialize `updated` value of entity document in response) 
- https://github.com/apache/openwhisk-client-go/pull/129 (Add updated field on Action struct)
