### PR TITLE
Add DelAnnotations field to support del annotation

### DIFF
--- a/whisk/action.go
+++ b/whisk/action.go
@@ -31,17 +31,18 @@ type ActionService struct {
 }
 
 type Action struct {
-	Namespace   string      `json:"namespace,omitempty"`
-	Name        string      `json:"name,omitempty"`
-	Version     string      `json:"version,omitempty"`
-	Exec        *Exec       `json:"exec,omitempty"`
-	Annotations KeyValueArr `json:"annotations,omitempty"`
-	Parameters  KeyValueArr `json:"parameters,omitempty"`
-	Limits      *Limits     `json:"limits,omitempty"`
-	Error       string      `json:"error,omitempty"`
-	Code        int         `json:"code,omitempty"`
-	Publish     *bool       `json:"publish,omitempty"`
-	Updated     int64       `json:"updated,omitempty"`
+	Namespace      string      `json:"namespace,omitempty"`
+	Name           string      `json:"name,omitempty"`
+	Version        string      `json:"version,omitempty"`
+	Exec           *Exec       `json:"exec,omitempty"`
+	Annotations    KeyValueArr `json:"annotations,omitempty"`
+	DelAnnotations []string    `json:"delAnnotations,omitempty"`
+	Parameters     KeyValueArr `json:"parameters,omitempty"`
+	Limits         *Limits     `json:"limits,omitempty"`
+	Error          string      `json:"error,omitempty"`
+	Code           int         `json:"code,omitempty"`
+	Publish        *bool       `json:"publish,omitempty"`
+	Updated        int64       `json:"updated,omitempty"`
 }
 
 type Exec struct {


### PR DESCRIPTION
Currently, if passing another annotations, original previous annotation
will be removed and the passed new annotations will be added.

It may give users some confused that why my previous annotation gone.
So it is better to not delete user's previous annotation when adding new
annotation, but at the same time, need to provide a feature that
support to delete annotation by user via ClI, e.g.
```shell
wsk action update hello --del-annotation key1 --del-annotation key2
```


another brother prs to support del annotation: 
* https://github.com/apache/openwhisk-cli/pull/488
* https://github.com/apache/openwhisk/pull/4940
