### PR TITLE
Bump up go version to 1.13.14 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     include:
         - os: linux
           sudo: required
-          go: "1.9.3"
+          go: "1.13.14"
           services: docker
           dist: xenial
 


### PR DESCRIPTION
the package `stretchr/testify` is not compatible with 1.9.3

![image](https://user-images.githubusercontent.com/1858477/90084292-8c086b80-dd47-11ea-9900-967dd2084bed.png)
