### PR TITLE
update status code if action returns error

### DIFF
--- a/whisk/activation.go
+++ b/whisk/activation.go
@@ -221,7 +221,7 @@ func (s *ActivationService) Get(activationID string) (*Activation, *http.Respons
 	return a, resp, nil
 }
 
-func GetStatusCodeForMessage(msg string) (int) {
+func GetStatusCodeForMessage(msg string) int {
 	var code int
 
 	switch msg {

--- a/whisk/activation.go
+++ b/whisk/activation.go
@@ -216,14 +216,12 @@ func (s *ActivationService) Get(activationID string) (*Activation, *http.Respons
 		return nil, resp, err
 	}
 
-	if a.Success == false {
-		a.StatusCode = GetStatusCodeForErrorMessage(a.Status)
-	}
+	a.StatusCode = GetStatusCodeForMessage(a.Status)
 
 	return a, resp, nil
 }
 
-func GetStatusCodeForErrorMessage(msg string) (int) {
+func GetStatusCodeForMessage(msg string) (int) {
 	var code int
 
 	switch msg {
@@ -233,6 +231,8 @@ func GetStatusCodeForErrorMessage(msg string) (int) {
 		code = 2
 	case "whisk internal error":
 		code = 3
+	default:
+		code = 0
 	}
 
 	return code

--- a/whisk/activation.go
+++ b/whisk/activation.go
@@ -216,7 +216,26 @@ func (s *ActivationService) Get(activationID string) (*Activation, *http.Respons
 		return nil, resp, err
 	}
 
+	if a.Success == false {
+		a.StatusCode = GetStatusCodeForErrorMessage(a.Status)
+	}
+
 	return a, resp, nil
+}
+
+func GetStatusCodeForErrorMessage(msg string) (int) {
+	var code int
+
+	switch msg {
+	case "application error":
+		code = 1
+	case "action developer error":
+		code = 2
+	case "whisk internal error":
+		code = 3
+	}
+
+	return code
 }
 
 func (s *ActivationService) Logs(activationID string) (*Activation, *http.Response, error) {


### PR DESCRIPTION
This PR is a fix for the issue which i raised for the activation's `statusCode`.
For more details about the issue, please click [here](https://github.com/apache/openwhisk-client-go/issues/141)

I have updated `statusCode` on the basis of `status` So that we can get correct `statusCode` according to `status`.