### PR TITLE
Removes pointer to pointer reference in activations

### DIFF
--- a/whisk/activation.go
+++ b/whisk/activation.go
@@ -60,10 +60,10 @@ type ActivationFilteredRow struct {
 }
 
 type Response struct {
-	Status     string  `json:"status"`
-	StatusCode int     `json:"statusCode"`
-	Success    bool    `json:"success"`
-	Result     *Result `json:"result,omitempty"`
+	Status     string `json:"status"`
+	StatusCode int    `json:"statusCode"`
+	Success    bool   `json:"success"`
+	Result     Result `json:"result,omitempty"`
 }
 
 type Result interface{}


### PR DESCRIPTION
PR #153 converts the whisk.Result type from a map[string]interface{} to an interface{} leaving Result type in whisk.Response as a pointer to Result which is now a pointer to a pointer.

This change updates the Response.Result to remove the double pointer pointing.