### PR TITLE
Add Env field 

### DIFF
--- a/whisk/action.go
+++ b/whisk/action.go
@@ -44,6 +44,7 @@ type Action struct {
 	Code           int         `json:"code,omitempty"`
 	Publish        *bool       `json:"publish,omitempty"`
 	Updated        int64       `json:"updated,omitempty"`
+	Env            KeyValueArr `json:"env,omitempty"`
 }
 
 type Exec struct {
@@ -92,7 +93,7 @@ func (action Action) ToHeaderString() string {
 }
 
 // ToSummaryRowString() returns a compound string of required parameters for printing
-//   from CLI command `wsk action list`.
+// from CLI command `wsk action list`.
 // ***Method of type Sortable***
 func (action Action) ToSummaryRowString() string {
 	var kind string


### PR DESCRIPTION
This PR adds a KeyValueArr field to the action struct.

I am working on adding a `--env` flag to wsk to support adding environment variables during [action initialization], and I figured I need another KeyValueArr when building the Action struct in openwhisk-cli.

The action struct is from the client-go so I'm adding it here, let me know if it's the correct way to do it!

[action initialization]: https://github.com/apache/openwhisk/blob/master/docs/actions-new.md#initialization